### PR TITLE
Max cache per user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 
 # JELLYFIN_URL=http://your-jellyfin-url 
 # MAX_CONCURRENT_JOBS=1
+# MAX_CACHED_PER_USER=10

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -388,7 +388,7 @@ export class AppService {
             this.logger.error(
               `Job ${jobId} failed with exit code ${code}. Input URL: ${job.inputUrl}`,
             );
-            reject(new Error(`FFmpeg process failed with exit code ${code}`));
+            // reject(new Error(`FFmpeg process failed with exit code ${code}`));
           }
         });
 
@@ -396,7 +396,7 @@ export class AppService {
           this.logger.error(
             `FFmpeg process error for job ${jobId}: ${error.message}`,
           );
-          reject(error);
+          // reject(error);
         });
       });
     } catch (error) {

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -265,7 +265,7 @@ export class AppService {
   }
 
   private getCompletedJobs(): number {
-    return this.activeJobs.filter((job) => job.status === 'completed').length;
+    return this.activeJobs.filter((job) => job.status === 'ready-for-removal').length;
   }
 
   private getUniqueDevices(): number {

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -319,10 +319,14 @@ export class AppService {
       const nextJobId = this.jobQueue[index]; // Access job ID by index
       let nextJob: Job = this.activeJobs.find((job) => job.id === nextJobId);
       
-      if (!this.userTooManyCachedItems(nextJobId) || this.isDeviceIdInOptimizeHistory(nextJob)) {
+      if (!this.userTooManyCachedItems(nextJobId) ) {
         nextJob.status = 'pending downloads limit'
-        // Skip this job if user cache limits are reached or the deviceID is in the recently finished jobs
+        // Skip this job if user cache limits are reached
         continue;
+      }
+      if(this.isDeviceIdInOptimizeHistory(nextJob)){
+        // Skip this job if deviceID is in the recently finished jobs
+        continue
       }
       // Start the job and remove it from the queue
       this.startJob(nextJobId);


### PR DESCRIPTION
- Added the ability to limit the amount of cached files a user can request. Settable in the .env. 
- Added the functionality to make sure users get equal optimizing time. If one user requests a bazillion jobs, it will still give optimizing time to other users who also request time.
- fixed a bug where server would crash if optimizing job was cancelled